### PR TITLE
mark `dbQuote` proc param to `dbFormatImpl` as {.nimcall.}

### DIFF
--- a/src/db_connector/private/dbutils.nim
+++ b/src/db_connector/private/dbutils.nim
@@ -1,7 +1,7 @@
 import ../db_common
 
 
-template dbFormatImpl*(formatstr: SqlQuery, dbQuote: proc (s: string): string, args: varargs[string]): string =
+template dbFormatImpl*(formatstr: SqlQuery, dbQuote: proc (s: string): string {.nimcall.}, args: varargs[string]): string =
   var res = ""
   var a = 0
   for c in items(string(formatstr)):


### PR DESCRIPTION
By default the type `proc (s: string): string` assumes {.closure.}, but the uses of `dbFormatImpl` only refer to implementations of `dbQuote` in each module which are good enough as {.nimcall.}.

Normally this doesn't matter, but if the rules of how template arguments are converted to argument types change to match normal procs in Nim in the future (as experimented in https://github.com/nim-lang/Nim/pull/23176), the passed `dbQuote` will be treated as an implicit conversion from a {.nimcall.} proc into a {.closure.} proc, which causes the effect tracker to treat it as an arbitrary procvar and assume it causes `RootEffect`. This won't necessarily be a problem but we can guard against it for the time being.