### PR TITLE
Allow `instantRows` with columns for `SqlPrepared`

### DIFF
--- a/src/db_connector/db_postgres.nim
+++ b/src/db_connector/db_postgres.nim
@@ -427,7 +427,7 @@ proc setColumnInfo(columns: var DbColumns; res: PPGresult, L: int32) =
     #columns[i].primaryKey = libpq does not have a function for that
     #columns[i].foreignKey = libpq does not have a function for that
 
-iterator instantRows*(db: DbConn; columns: var DbColumns; query: SqlQuery;
+iterator instantRows*(db: DbConn; columns: var DbColumns; query: SqlQuery|SqlPrepared;
                       args: varargs[string, `$`]): InstantRow
                       {.tags: [ReadDbEffect].} =
   setupSingeRowQuery(db, query, args)

--- a/src/db_connector/db_sqlite.nim
+++ b/src/db_connector/db_sqlite.nim
@@ -458,7 +458,7 @@ proc setColumns(columns: var DbColumns; x: PStmt) =
     toTypeKind(columns[i].typ, column_type(x, i))
     columns[i].tableName = $column_table_name(x, i)
 
-iterator instantRows*(db: DbConn; columns: var DbColumns; query: SqlQuery,
+iterator instantRows*(db: DbConn; columns: var DbColumns; query: SqlQuery|SqlPrepared;,
                       args: varargs[string, `$`]): InstantRow
                       {.tags: [ReadDbEffect].} =
   ## Similar to `instantRows iterator <#instantRows.i,DbConn,SqlQuery,varargs[string,]>`_,


### PR DESCRIPTION
Allow `instantRows` iterator to accept `SqlPrepared` as well as `SqlQuery` for query argument